### PR TITLE
Add run-application Terraform module for multi-container deploy

### DIFF
--- a/modules/run-application/README.md
+++ b/modules/run-application/README.md
@@ -1,0 +1,96 @@
+# run-application
+
+Modulo Terraform per il deploy di uno o più container Docker, con registrazione metadati su Consul.
+
+## Nome modulo
+Il nome richiesto `run-application` è coerente e chiaro. In alternativa, solo se vuoi enfatizzare la natura di stack, puoi usare `run-application-stack`.
+
+## Provider usati
+- `cybershard/docker` `1.0.0`
+- `hashicorp/consul` `2.23.0`
+- `hashicorp/random` (per UUID persistenti in state)
+
+## Moduli interni usati
+- `environment-resolver` (risolve `env_uuid`)
+- `environment-networks-registry` (risolve reti provider/app e mapping nome/uuid)
+
+## Input
+| Variabile | Tipo | Descrizione |
+|---|---|---|
+| `env` | `string` | Nome logico ambiente |
+| `application_network_name` | `string` | Rete applicativa obbligatoria su cui collegare tutti i container |
+| `attach_infrastructure_network` | `bool` | Se `true`, collega tutti i container anche alla rete provider |
+| `containers_spec_file` | `string` | Path file JSON con la definizione dei container |
+
+## Struttura JSON supportata
+```json
+[
+  {
+    "name": "my-container",
+    "image": "nginx:1.27",
+    "build": {
+      "context": "./docker/nginx",
+      "file": "Dockerfile"
+    },
+    "networks": ["app-a", "app-b"],
+    "attach_on_provider": false,
+    "ports": [
+      {"host": "8080", "container": "80", "protocol": "tcp"}
+    ],
+    "mounts": [
+      {"/etc/localtime": "/etc/localtime"}
+    ],
+    "volumes": [
+      {"name": "nginx-data", "path": "/var/lib/nginx", "destroy_on_recreate": false}
+    ],
+    "devices": [
+      {"name": "/dev/ttyUSB0", "path": "/dev/ttyUSB0"}
+    ],
+    "var": {
+      "environment": {
+        "A": "B"
+      }
+    }
+  }
+]
+```
+
+> Nota: la parte `var.secrets` è volutamente ignorata in questa versione.
+
+## Comportamento
+- Se `build` è presente, viene creata una `docker_image` da context/dockerfile e usata al posto di `image`.
+- Le reti indicate in `networks` devono esistere nell'ambiente; in caso contrario il piano fallisce.
+- Ogni container viene sempre collegato a `application_network_name`.
+- `attach_infrastructure_network` forza l'attach alla rete provider per tutti.
+- `attach_on_provider` abilita l'attach provider per il singolo container.
+- Viene generato un UUID stack (`random_uuid.application`) e un UUID per container (`random_uuid.container`).
+- I metadati vengono scritti in Consul con il path:
+  - `applications/<env-uuid>/<app-uuid>/<container-uuid>/...`
+
+## Output principali
+- `env_uuid`
+- `application_uuid`
+- `container_uuids`
+- `provider_network_uuid`
+- `app_network_uuids`
+- `container_ips_by_network_uuid`
+
+## Esempio uso
+```hcl
+module "run_application" {
+  source = "../../modules/run-application"
+
+  env                           = "home"
+  application_network_name      = "app-core"
+  attach_infrastructure_network = false
+  containers_spec_file          = "${path.module}/containers.json"
+}
+```
+
+## JSON file vs variabili Terraform
+Per questo scenario è corretto usare un file JSON esterno:
+- facilita gestione di stack multi-container complessi
+- più semplice da versionare separatamente
+- evita input Terraform troppo annidati e verbosi
+
+Se in futuro vuoi validazioni più forti a plan-time, possiamo aggiungere anche una variabile tipizzata alternativa (`list(object(...))`) mantenendo il JSON come opzione.

--- a/modules/run-application/main.tf
+++ b/modules/run-application/main.tf
@@ -1,0 +1,234 @@
+module "environment" {
+  source = "../environment-resolver"
+  env    = var.env
+}
+
+module "environment_networks" {
+  source = "../environment-networks-registry"
+  env    = var.env
+}
+
+locals {
+  raw_containers = jsondecode(file(var.containers_spec_file))
+
+  containers = {
+    for container in local.raw_containers :
+    container.name => merge(container, {
+      networks           = distinct(concat([var.application_network_name], try(container.networks, [])))
+      attach_on_provider = try(container.attach_on_provider, false)
+      ports              = try(container.ports, [])
+      mounts             = try(container.mounts, [])
+      volumes            = try(container.volumes, [])
+      devices            = try(container.devices, [])
+      environment_vars   = try(container.var.environment, {})
+      build              = try(container.build, null)
+    })
+  }
+
+  app_network_uuid_by_name = module.environment_networks["list-by-name"].apps
+  app_networks_by_name = {
+    for net_uuid, net_name in module.environment_networks["list-by-uuid"].apps :
+    net_name => {
+      uuid = net_uuid
+      name = net_name
+    }
+  }
+
+  selected_app_networks_by_container = {
+    for container_name, container in local.containers :
+    container_name => {
+      for network_name in container.networks :
+      network_name => local.app_networks_by_name[network_name]
+      if contains(keys(local.app_networks_by_name), network_name)
+    }
+  }
+
+  invalid_networks_by_container = {
+    for container_name, container in local.containers :
+    container_name => [
+      for network_name in container.networks : network_name
+      if !contains(keys(local.app_networks_by_name), network_name)
+    ]
+  }
+
+  invalid_networks = distinct(flatten(values(local.invalid_networks_by_container)))
+
+  build_containers = {
+    for container_name, container in local.containers :
+    container_name => container
+    if container.build != null
+  }
+
+  managed_volumes = {
+    for volume in flatten([
+      for container_name, container in local.containers : [
+        for volume in container.volumes : {
+          key                 = "${container_name}::${volume.name}"
+          container_name      = container_name
+          name                = volume.name
+          path                = volume.path
+          destroy_on_recreate = try(volume.destroy_on_recreate, false)
+        }
+      ]
+    ]) : volume.key => volume
+  }
+
+  container_networks_with_provider = {
+    for container_name, container in local.containers :
+    container_name => concat(
+      [for _, net in local.selected_app_networks_by_container[container_name] : net.name],
+      (var.attach_infrastructure_network || container.attach_on_provider)
+      ? [module.environment_networks["list-by-uuid"].provider[module.environment_networks["list-uuid"].provider]]
+      : []
+    )
+  }
+
+  container_env = {
+    for container_name, container in local.containers :
+    container_name => [
+      for key, value in container.environment_vars : "${key}=${value}"
+    ]
+  }
+}
+
+resource "random_uuid" "application" {}
+
+resource "random_uuid" "container" {
+  for_each = local.containers
+}
+
+resource "docker_image" "built" {
+  for_each = local.build_containers
+
+  name = each.value.image
+
+  build {
+    context    = each.value.build.context
+    dockerfile = each.value.build.file
+  }
+}
+
+resource "docker_volume" "managed" {
+  for_each = local.managed_volumes
+
+  name          = each.value.name
+  driver        = "local"
+  force_destroy = each.value.destroy_on_recreate
+}
+
+resource "docker_container" "this" {
+  for_each = local.containers
+
+  name  = each.value.name
+  image = contains(keys(docker_image.built), each.key) ? docker_image.built[each.key].image_id : each.value.image
+
+  dynamic "networks_advanced" {
+    for_each = toset(local.container_networks_with_provider[each.key])
+    content {
+      name = networks_advanced.value
+    }
+  }
+
+  dynamic "ports" {
+    for_each = each.value.ports
+    content {
+      internal = tonumber(ports.value.container)
+      external = tonumber(ports.value.host)
+      protocol = ports.value.protocol
+    }
+  }
+
+  dynamic "volumes" {
+    for_each = each.value.mounts
+    content {
+      host_path      = keys(volumes.value)[0]
+      container_path = values(volumes.value)[0]
+    }
+  }
+
+  dynamic "volumes" {
+    for_each = each.value.volumes
+    content {
+      volume_name    = docker_volume.managed["${each.key}::${volumes.value.name}"].name
+      container_path = volumes.value.path
+    }
+  }
+
+  dynamic "devices" {
+    for_each = each.value.devices
+    content {
+      host_path      = devices.value.name
+      container_path = devices.value.path
+    }
+  }
+
+  env = local.container_env[each.key]
+
+  lifecycle {
+    precondition {
+      condition     = length(local.invalid_networks) == 0
+      error_message = "One or more requested app networks are not part of environment '${var.env}': ${join(", ", local.invalid_networks)}"
+    }
+  }
+}
+
+locals {
+  container_network_ip_by_uuid = {
+    for container_name, container in docker_container.this :
+    container_name => merge(
+      {
+        for network in container.network_data :
+        lookup(local.app_network_uuid_by_name, network.network_name, "") => network.ip_address
+        if contains(keys(local.app_network_uuid_by_name), network.network_name)
+      },
+      {
+        for network in container.network_data :
+        module.environment_networks["list-uuid"].provider => network.ip_address
+        if network.network_name == module.environment_networks["list-by-uuid"].provider[module.environment_networks["list-uuid"].provider]
+      }
+    )
+  }
+
+  container_consul_entries = {
+    for container_name, container in local.containers :
+    container_name => merge(
+      {
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/name"  = container.name
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/image" = container.image
+      },
+      container.build != null ? {
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/context-path" = container.build.context
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/Dockerfile"   = file("${container.build.context}/${container.build.file}")
+      } : {},
+      {
+        for network_uuid, ip in local.container_network_ip_by_uuid[container_name] :
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/networks/${network_uuid}/ip" => ip
+      },
+      {
+        for network_uuid, _ in local.container_network_ip_by_uuid[container_name] :
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/networks/${network_uuid}/port-map" => jsonencode(container.ports)
+      },
+      {
+        for volume in container.volumes :
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/volumes/${volume.name}" => volume.path
+      },
+      {
+        for device in container.devices :
+        "applications/${module.environment.env_uuid}/${random_uuid.application.result}/${random_uuid.container[container_name].result}/devices/${device.name}" => device.path
+      }
+    )
+  }
+}
+
+resource "consul_keys" "application_registry" {
+  for_each = local.container_consul_entries
+
+  dynamic "key" {
+    for_each = each.value
+    content {
+      path   = key.key
+      value  = key.value
+      delete = true
+    }
+  }
+}

--- a/modules/run-application/outputs.tf
+++ b/modules/run-application/outputs.tf
@@ -1,0 +1,32 @@
+output "env_uuid" {
+  description = "Resolved UUID of the target environment"
+  value       = module.environment.env_uuid
+}
+
+output "application_uuid" {
+  description = "Stable UUID representing the deployed container stack"
+  value       = random_uuid.application.result
+}
+
+output "container_uuids" {
+  description = "Stable UUIDs generated for each container"
+  value = {
+    for container_name, container_uuid in random_uuid.container :
+    container_name => container_uuid.result
+  }
+}
+
+output "provider_network_uuid" {
+  description = "UUID of the provider network for the environment"
+  value       = module.environment_networks["list-uuid"].provider
+}
+
+output "app_network_uuids" {
+  description = "UUID map of application networks resolved by name"
+  value       = module.environment_networks["list-by-name"].apps
+}
+
+output "container_ips_by_network_uuid" {
+  description = "Container IP addresses indexed by network UUID"
+  value       = local.container_network_ip_by_uuid
+}

--- a/modules/run-application/provider.tf
+++ b/modules/run-application/provider.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.11.0"
+
+  required_providers {
+    docker = {
+      source  = "cybershard/docker"
+      version = "1.0.0"
+    }
+    consul = {
+      source  = "hashicorp/consul"
+      version = "2.23.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6.0"
+    }
+  }
+}

--- a/modules/run-application/variables.tf
+++ b/modules/run-application/variables.tf
@@ -1,0 +1,20 @@
+variable "env" {
+  type        = string
+  description = "Logical environment name used to resolve environment and networks from Consul"
+}
+
+variable "application_network_name" {
+  type        = string
+  description = "Application network name that every container must join"
+}
+
+variable "attach_infrastructure_network" {
+  type        = bool
+  description = "When true, all containers are attached to the provider network"
+  default     = false
+}
+
+variable "containers_spec_file" {
+  type        = string
+  description = "Path to a JSON file describing containers to deploy"
+}


### PR DESCRIPTION
### Motivation
- Creare un modulo Terraform `run-application` per il deploy di uno o più container Docker usando i provider richiesti e registrare i metadati in Consul.
- Integrare i moduli interni esistenti `environment-resolver` e `environment-networks-registry` per risolvere `env_uuid` e le reti dell'ambiente.
- Fornire input centralizzato via file JSON per descrivere stack multi-container (image/build, reti, porte, mount, volumi, devices, env) e generare UUID persistenti per lo stack e per ogni container.
- Ignorare la parte di `var.secrets` in questa versione come richiesto; concentrare l'implementazione sulle altre caratteristiche.

### Description
- Aggiunto nuovo modulo `modules/run-application` con i file `provider.tf`, `variables.tf`, `main.tf`, `outputs.tf` e `README.md` e configurazione dei provider `cybershard/docker` `1.0.0`, `hashicorp/consul` `2.23.0` e `hashicorp/random`. 
- Il modulo legge il file JSON indicato da `containers_spec_file`, normalizza le specifiche e crea opzionalmente `docker_image` (build), `docker_volume` e `docker_container` con reti, porte, mount FS, volumi Docker, device e variabili ambiente. 
- Implementata validazione delle reti applicative (fallisce con `precondition` se una rete richiesta non appartiene all'ambiente) e opzione globale/per-container per agganciare anche la rete provider. 
- Generati UUID persistenti tramite risorse `random_uuid` (`application` per lo stack, `container` per ogni container) e scrittura dei metadati in Consul sotto i path `applications/<env-uuid>/<app-uuid>/<container-uuid>/...`; esposti output chiave (`env_uuid`, `application_uuid`, `container_uuids`, `provider_network_uuid`, `app_network_uuids`, `container_ips_by_network_uuid`).

### Testing
- Tentativo di eseguire `terraform fmt -recursive modules/run-application` che non è riuscito perché il CLI Terraform non è installato in questo ambiente, quindi il formatting/validation automatico non è stato eseguito (fallito).
- Non sono stati eseguiti altri test automatici del runtime Terraform in questo ambiente; i file sono stati creati e verificati staticamente con comandi di ricerca/sostituzione e ispezione.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698535ce5a288332bf1f29b6536b295b)