### PR TITLE
chore: update CHANGELOG for 0.1.1 run-application indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog,
 and this project adheres to Semantic Versioning.
 
+## [0.1.1] 2026-02-09
+
+### Added
+- run-application: aggiornamento indici Consul `indexes/applications/by-name/<env-uuid>/containers/<container-name>` con payload JSON `{ name, container-uid, app, app-uuid }`
+- run-application: aggiornamento indici Consul `indexes/applications/by-apps/<env-uuid>/apps/<app-name>` con payload JSON mappato per container `{ <container-name>: { uuid, app, app-uuid } }`
+- run-application: nuova variabile opzionale `application_name` per definire il nome applicazione negli indici (fallback al basename di `containers_spec_file` senza `.json`)
+
 ## [0.1.0] 2026-02-09
 
 ### Added

--- a/modules/run-application/README.md
+++ b/modules/run-application/README.md
@@ -21,6 +21,7 @@ Il nome richiesto `run-application` è coerente e chiaro. In alternativa, solo s
 | `application_network_name` | `string` | Rete applicativa obbligatoria su cui collegare tutti i container |
 | `attach_infrastructure_network` | `bool` | Se `true`, collega tutti i container anche alla rete provider |
 | `containers_spec_file` | `string` | Path file JSON con la definizione dei container |
+| `application_name` | `string` | Nome logico applicazione per gli indici Consul (`null` => basename di `containers_spec_file` senza `.json`) |
 
 ## Struttura JSON supportata
 ```json
@@ -66,6 +67,9 @@ Il nome richiesto `run-application` è coerente e chiaro. In alternativa, solo s
 - Viene generato un UUID stack (`random_uuid.application`) e un UUID per container (`random_uuid.container`).
 - I metadati vengono scritti in Consul con il path:
   - `applications/<env-uuid>/<app-uuid>/<container-uuid>/...`
+- Vengono aggiornati anche gli indici Consul:
+  - `indexes/applications/by-name/<env-uuid>/containers/<container-name>` => `{ "name": ..., "container-uid": ..., "app": ..., "app-uuid": ... }`
+  - `indexes/applications/by-apps/<env-uuid>/apps/<app-name>` => `{ "<container-name>": { "uuid": ..., "app": ..., "app-uuid": ... } }`
 
 ## Output principali
 - `env_uuid`

--- a/modules/run-application/variables.tf
+++ b/modules/run-application/variables.tf
@@ -18,3 +18,9 @@ variable "containers_spec_file" {
   type        = string
   description = "Path to a JSON file describing containers to deploy"
 }
+
+variable "application_name" {
+  type        = string
+  description = "Logical application name used for Consul indexes; defaults to containers_spec_file basename"
+  default     = null
+}


### PR DESCRIPTION
### Motivation
- Documentare la release `0.1.1` e descrivere gli aggiornamenti al modulo `run-application` riguardo agli indici Consul e la nuova variabile `application_name`.

### Description
- Aggiunta della sezione `## [0.1.1]` in `CHANGELOG.md` che elenca gli indici `indexes/applications/by-name/<env-uuid>/containers/<container-name>` e `indexes/applications/by-apps/<env-uuid>/apps/<app-name>` con i payload JSON e la variabile opzionale `application_name` (fallback al basename di `containers_spec_file` senza `.json`).

### Testing
- Eseguiti i comandi `git add CHANGELOG.md && git commit -m "chore: bump changelog for 0.1.1"` e `nl -ba CHANGELOG.md | sed -n '1,60p'` per verificare l'inserimento, entrambi i comandi sono riusciti.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a6c98984c83328f5e0a43b0fb9bf6)